### PR TITLE
Update to bevy 0.19.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gauge"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2024"
 description = "A flexible attribute and stat system for Bevy"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 avian3d = ["dep:avian3d"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_log"] }
+bevy = { version = "0.19.0-rc.2", default-features = false, features = ["bevy_log"] }
 lasso = { version = "0.7", features = ["multi-threaded"] }
 inventory = "0.3"
 bevy_gauge_macros = { path = "./macros", version = "0.4.3" }

--- a/examples/equipment.rs
+++ b/examples/equipment.rs
@@ -198,7 +198,7 @@ fn equip(
 ) {
     let wielder_name = q_name.get(wielder).map(|n| n.as_str()).unwrap_or("???");
 
-    let Ok((item_name, mut state, mods, mut reqs)) = q_equipment.get_mut(item) else {
+    let Ok((item_name, mut state, mods, reqs)) = q_equipment.get_mut(item) else {
         println!("  Item has no equipment components!");
         return;
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -54,11 +54,15 @@ struct AttrsEntityCommand {
 }
 
 impl EntityCommand for AttrsEntityCommand {
+    type Out = ();
     fn apply(self, entity_world: EntityWorldMut<'_>) {
         let entity = entity_world.id();
         let world = entity_world.into_world_mut();
         let mut state = SystemState::<AttributesMut>::new(world);
-        let mut attrs_mut = state.get_mut(world);
+        let Ok(mut attrs_mut) = state.get_mut(world) else {
+            debug!("could not get attributes for {entity}. skipping...");
+            return;
+        };
         let mut bound = BoundAttributesMut {
             entity,
             attrs: &mut attrs_mut,

--- a/src/requirements.rs
+++ b/src/requirements.rs
@@ -51,13 +51,34 @@ impl AttributeRequirement {
         }
     }
 
+    #[cfg(test)]
+    fn compiled(source: impl Into<String>) -> Self {
+        let source = source.into();
+        Self {
+            compiled: Self::compile_internal(source.as_str()),
+            source,
+        }
+    }
+
     /// Compile the expression eagerly. Called by the component hook.
     pub fn compile(&mut self) {
-        if self.compiled.is_some() { return; }
-        match Expr::compile(&self.source, None) {
-            Ok(expr) => { self.compiled = Some(expr); }
+        if self.compiled.is_some() {
+            return;
+        }
+        if let Some(expr) = Self::compile_internal(&self.source) {
+            self.compiled = Some(expr);
+        }
+    }
+
+    fn compile_internal(source: &str) -> Option<Expr> {
+        match Expr::compile(source, None) {
+            Ok(expr) => Some(expr),
             Err(err) => {
-                warn!("AttributeRequirement compile error for '{}': {}", self.source, err);
+                warn!(
+                    "AttributeRequirement compile error for '{}': {}",
+                    source, err
+                );
+                None
             }
         }
     }
@@ -69,7 +90,10 @@ impl AttributeRequirement {
         match &self.compiled {
             Some(expr) => expr.evaluate(&attrs.context) != 0.0,
             None => {
-                warn!("AttributeRequirement::check called before compile for '{}'", self.source);
+                warn!(
+                    "AttributeRequirement::check called before compile for '{}'",
+                    self.source
+                );
                 false
             }
         }
@@ -101,10 +125,10 @@ impl<S: Into<String>> From<S> for AttributeRequirement {
 pub struct AttributeRequirements(pub Vec<AttributeRequirement>);
 
 fn compile_requirements_hook(mut world: DeferredWorld, ctx: HookContext) {
-    let Some(mut reqs) = world.get_mut::<AttributeRequirements>(ctx.entity) else { return; };
-    for req in reqs.0.iter_mut() {
-        req.compile();
-    }
+    let Some(mut reqs) = world.get_mut::<AttributeRequirements>(ctx.entity) else {
+        return;
+    };
+    reqs.compile();
 }
 
 impl AttributeRequirements {
@@ -120,6 +144,13 @@ impl AttributeRequirements {
     /// Merge requirements from another set into this one.
     pub fn combine(&mut self, other: &AttributeRequirements) {
         self.0.extend(other.0.iter().cloned());
+    }
+
+    /// Compile each [`AttributeRequirement`] eagerly. Called by the component hook.
+    pub fn compile(&mut self) {
+        for req in self.0.iter_mut() {
+            req.compile();
+        }
     }
 
     /// Check whether **all** requirements are satisfied.
@@ -204,7 +235,7 @@ mod tests {
     fn single_requirement_met() {
         let interner = test_interner();
         let attrs = make_attrs(&interner, &[("Strength", 25.0)]);
-        let req = AttributeRequirement::new("Strength >= 10");
+        let req = AttributeRequirement::compiled("Strength >= 10");
         assert!(req.met(&attrs));
     }
 
@@ -212,7 +243,7 @@ mod tests {
     fn single_requirement_not_met() {
         let interner = test_interner();
         let attrs = make_attrs(&interner, &[("Strength", 5.0)]);
-        let req = AttributeRequirement::new("Strength >= 10");
+        let req = AttributeRequirement::compiled("Strength >= 10");
         assert!(!req.met(&attrs));
     }
 
@@ -220,7 +251,11 @@ mod tests {
     fn requirements_all_met() {
         let interner = test_interner();
         let attrs = make_attrs(&interner, &[("Strength", 25.0), ("Level", 10.0)]);
-        let reqs = AttributeRequirements::from(vec!["Strength >= 10", "Level >= 5"]);
+        let reqs = {
+            let mut reqs = AttributeRequirements::from(vec!["Strength >= 10", "Level >= 5"]);
+            reqs.compile();
+            reqs
+        };
         assert!(reqs.met(&attrs));
     }
 
@@ -228,7 +263,11 @@ mod tests {
     fn requirements_partial_met() {
         let interner = test_interner();
         let attrs = make_attrs(&interner, &[("Strength", 25.0), ("Level", 3.0)]);
-        let reqs = AttributeRequirements::from(vec!["Strength >= 10", "Level >= 5"]);
+        let reqs = {
+            let mut reqs = AttributeRequirements::from(vec!["Strength >= 10", "Level >= 5"]);
+            reqs.compile();
+            reqs
+        };
         assert!(!reqs.met(&attrs));
     }
 
@@ -243,7 +282,7 @@ mod tests {
     fn le_zero_check() {
         let interner = test_interner();
         let attrs = make_attrs(&interner, &[("ProjectileLife", 0.0)]);
-        let req = AttributeRequirement::new("ProjectileLife <= 0");
+        let req = AttributeRequirement::compiled("ProjectileLife <= 0");
         assert!(req.met(&attrs));
     }
 


### PR DESCRIPTION
Fix attribute requirement tests by eagerly compiling requirements
(also added a test helper `AttributeComponent::compiled` to make future testing easier)

also also fix a clippy lint on an example